### PR TITLE
가로모드 대응 todo 및 관련 주석 추가

### DIFF
--- a/app/src/main/java/com/example/movietrailer/MainActivity.kt
+++ b/app/src/main/java/com/example/movietrailer/MainActivity.kt
@@ -9,6 +9,9 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+
+        // todo: 가로모드 대응 필요
+        // 가로모드일 변경 시 현재 선택된 페이지 유지하기 위해 조건문 추가
         if (savedInstanceState == null) {
             supportFragmentManager.beginTransaction()
                 .replace(R.id.container, PagerFragment.newInstance())


### PR DESCRIPTION
- 가로모드 대응 todo 추가
- MainActivity.onCreate()에 savedinstanceState == null 체크 추가한 이유 주석 추가
  - savedinstanceState에 값이 있을 떄도 pagerFragmet 생성하면 아래와 같은 이슈 발생
    -  스와이프한한 이후 가로모드 전환하면 첫 번째 페이지로 돌아감
  - configuration change(ex, 가로모드 전환)로 액티비티가 재생성될 떄 pagerFragment도 새로 생성하기 때문
  - 처음 액티비티 생성될 떄만 pagerFragment 생성하기 위해 savedinstanceState가 null일 때만 pagerFragment 생성하도록 변경
