### PR TITLE
PagerFragment replace 시 commintNow() 사용 관련 주석 추가

### DIFF
--- a/app/src/main/java/com/example/movietrailer/MainActivity.kt
+++ b/app/src/main/java/com/example/movietrailer/MainActivity.kt
@@ -15,7 +15,7 @@ class MainActivity : AppCompatActivity() {
         if (savedInstanceState == null) {
             supportFragmentManager.beginTransaction()
                 .replace(R.id.container, PagerFragment.newInstance())
-                .commitNow()
+                .commitNow() // commitNow() 사용 이유, https://github.com/lminsu/MovieTrailer/issues/3#issue-2600864620
         }
     }
 }


### PR DESCRIPTION
- commit()을 사용하면 IllegalStateException 발생 가능성 존재
  - 만약 transaction이 `onSaveInstanceState() 호출 이후 수행`되면 IllegalStateException 발생
    - `onSaveInstanceState() 호출 이후 commit()이 수행`되면, 액티비티 재생성 시 commit한 내용이 savedState에 저장되어 있지 않음
    - → 사용자는 transaction이 수행되었다고 생각하는데, 재생성된 모습은 transaction이 수행되지 않은 모습임
    - → 위와 같은 이유로 안드로이드 코드에서는 익셉션 발생하도록 구현되어 있음
  - (참고) https://www.androiddesignpatterns.com/2013/08/fragment-transaction-commit-state-loss.html
- 해결책: commitNow() 또는 commitAllowingStateLoss() 사용
  - transaction이 유실되도 상관 없으면 commitAllowingStateLoss() 사용
  - transaction이 수행되는게 꼭 필요하면 commitNow() 사용
    - 단, addToBackstack()이 필요하면 commitNow() 사용 못함
    - ㄴ 관련 내용: https://medium.com/@bherbst/the-many-flavors-of-commit-186608a015b1