### PR TITLE
MainViewModel 생성 함수 추가

### DIFF
--- a/app/src/main/java/com/example/movietrailer/ui/main/MainFragment.kt
+++ b/app/src/main/java/com/example/movietrailer/ui/main/MainFragment.kt
@@ -37,12 +37,7 @@ class MainFragment : Fragment() {
             movieId = it.getLong(MOVIE_ID)
         }
 
-        viewModel = ViewModelProvider(owner = this, object : ViewModelProvider.Factory {
-            override fun <T : ViewModel> create(modelClass: Class<T>): T {
-                @Suppress("UNCHECKED_CAST")
-                return MainViewModel(repository = VideoRepository()) as T
-            }
-        })[MainViewModel::class.java]
+        viewModel = makeMainViewModel()
     }
 
     override fun onCreateView(
@@ -96,5 +91,15 @@ class MainFragment : Fragment() {
 
     private fun getMovie(movieId: Long): Movie? {
         return (parentFragment as? PagerFragment)?.getMovie(movieId)
+    }
+
+    // todo: hilt 사용
+    @Suppress("UNCHECKED_CAST")
+    private fun makeMainViewModel(): MainViewModel {
+        return ViewModelProvider(owner = this, object : ViewModelProvider.Factory {
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                return MainViewModel(repository = VideoRepository()) as T
+            }
+        })[MainViewModel::class.java]
     }
 }


### PR DESCRIPTION
- 뷰모델 생성 함수 추가 - 뷰모델 생성 코드가 onCreate()에 같이 있으니 코드 보기가 불편하여 함수 생성함
- hilt 사용 todo 추가
- (참고) Fragment 초기화 때 뷰모델을 생성하면 안 되는 이유(onCreate() 때 뷰모델 생성한 이유)
  - Fragment 초기화 때 뷰모델 생성 시 아래와 같은 에러 발생함
    - ![image](https://github.com/user-attachments/assets/a36d521c-08bd-4bd8-ab75-708607b8c4ce)
    - Fragment가 Attach 되기 전에 뷰모델을 생성했기 떄문
      - `ViewModelProvider를 통해 뷰모델을 생성할 떄`는 프래그먼트가 attach 안 되어 있으면 에러 발생함
      - (참고) 코틀린 생성자 관련 문서, https://kotlinlang.org/docs/classes.html
- (참고) 뷰모델 생성 시 ViewModelProvider를 사용하는 이유
  - configuration change 때도 뷰모델이 살아있을 수 있게 해줌(재생성 하지 않고 기존에 만들어져있던 것 사용함)
    - configuration change 때도 데이터 유지함
    - → 더 나은 사용자 경험 제공, cpu 사용 측면에서 이득(뷰모델 및 데이터들을 새로 만들지 않아도 되서)
    - 여러 프래그먼트가 하나의 뷰모델을 공유할 수 있음
    - → 데이터 일관성 유지, 메모리측면에서도 이득(하나만 생성하니까)
