### PR TITLE
불필요한 newInstance() 함수 제거

### DIFF
--- a/app/src/main/java/com/example/movietrailer/MainActivity.kt
+++ b/app/src/main/java/com/example/movietrailer/MainActivity.kt
@@ -14,7 +14,7 @@ class MainActivity : AppCompatActivity() {
         // 가로모드일 변경 시 현재 선택된 페이지 유지하기 위해 조건문 추가
         if (savedInstanceState == null) {
             supportFragmentManager.beginTransaction()
-                .replace(R.id.container, PagerFragment.newInstance())
+                .replace(R.id.container, PagerFragment())
                 .commitNow() // commitNow() 사용 이유, https://github.com/lminsu/MovieTrailer/issues/3#issue-2600864620
         }
     }

--- a/app/src/main/java/com/example/movietrailer/ui/pager/PagerFragment.kt
+++ b/app/src/main/java/com/example/movietrailer/ui/pager/PagerFragment.kt
@@ -19,10 +19,6 @@ import kotlinx.coroutines.launch
 
 class PagerFragment : Fragment() {
 
-    companion object {
-        fun newInstance() = PagerFragment()
-    }
-
     private lateinit var viewModel: PagerViewModel
     private var _binding: FragmentPagerBinding? = null
     private val binding: FragmentPagerBinding get() = _binding!!


### PR DESCRIPTION
- 불필요한 newInstance() 함수 제거
  - PagerFragment()는 기본 생성자로 생성하므로 newInstance() 함수 불필요 하여 제거
  - newInstance() 함수는 `Fragment 생성 시 데이터를 넘겨줄 필요가 있을 떄` 사용함, 그 이유는 아래와 같음
    - 안드로이드는 액티비티 재생성으로 인한 프래그먼트 재생성 시 항상 기본 생성자를 호출함
    - → fragment에 생성자 파라미터를 정의하면, 기본 생성자가 없기 때문에 프래그먼트 재생성 시 에러 발생함
    - → fragment에 생성자 파라미터를 추가하고 싶으면, `프래그먼트의 argument 프로퍼티`에 번들로 넣어주어야 함, 넣은 번들은 onCreate() 때 받을 수 있음
    - 넣을 떄 코드 예시
      - ![image](https://github.com/user-attachments/assets/cf8fcd40-1064-4721-9542-885a8f96d8f5)
    - 받을 때 코드 예시
      - ![image](https://github.com/user-attachments/assets/e6ebb0a5-a09c-458f-bd03-ce9754b65421)

